### PR TITLE
Misguide the timezone for logs

### DIFF
--- a/modules/web/src/logs/template.html
+++ b/modules/web/src/logs/template.html
@@ -95,7 +95,6 @@ limitations under the License.
       to
       <kd-date [date]="podLogs?.info.toDate"
                format="short"> </kd-date>
-      UTC
     </div>
 
     <div fxFlex></div>


### PR DESCRIPTION
Currently, pod start time and end time are showing local (browser/system) timezone, This word misguide the time in UTC. So, I propose to remove UTC word.